### PR TITLE
Feature/artifact-archive

### DIFF
--- a/artifact/extExists.go
+++ b/artifact/extExists.go
@@ -1,13 +1,16 @@
 package artifact
 
 import (
+	"Builder/utils"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
-//find file with extension and return file name
+// find file with extension and return file name
 func ExtExistsFunction(dirPath string, ext string) (bool, string) {
+	fmt.Println(dirPath)
 	found := false
 	d, err := os.Open(dirPath)
 	if err != nil {
@@ -25,10 +28,18 @@ func ExtExistsFunction(dirPath string, ext string) (bool, string) {
 
 	for _, file := range files {
 		if file.Mode().IsRegular() {
-			if filepath.Ext(file.Name()) == ext {
-				fileName = file.Name()
-				found = true
+			if ext == ".exe" {
+				if filepath.Ext(file.Name()) == ext {
+					fileName = file.Name()
+					found = true
+				}
+			} else if ext == "executable" {
+				if file.Mode()&0111 != 0 && file.Name() == strings.TrimSuffix(utils.GetName(), ".git") {
+					fileName = file.Name()
+					found = true
+				}
 			}
+
 		}
 	}
 	return found, fileName

--- a/artifact/extExists.go
+++ b/artifact/extExists.go
@@ -28,12 +28,12 @@ func ExtExistsFunction(dirPath string, ext string) (bool, string) {
 
 	for _, file := range files {
 		if file.Mode().IsRegular() {
-			if ext == ".exe" {
+			if ext != "executable" {
 				if filepath.Ext(file.Name()) == ext {
 					fileName = file.Name()
 					found = true
 				}
-			} else if ext == "executable" {
+			} else {
 				if file.Mode()&0111 != 0 && file.Name() == strings.TrimSuffix(utils.GetName(), ".git") {
 					fileName = file.Name()
 					found = true

--- a/artifact/extExists.go
+++ b/artifact/extExists.go
@@ -10,7 +10,6 @@ import (
 
 // find file with extension and return file name
 func ExtExistsFunction(dirPath string, ext string) (bool, string) {
-	fmt.Println(dirPath)
 	found := false
 	d, err := os.Open(dirPath)
 	if err != nil {

--- a/artifact/zipDir.go
+++ b/artifact/zipDir.go
@@ -1,68 +1,135 @@
 package artifact
 
 import (
+	"archive/tar"
 	"archive/zip"
+	"compress/gzip"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
+	"runtime"
 )
 
-//Npm creates zip from files passed in as arg
+// Npm creates zip from files passed in as arg
 func ZipArtifactDir() {
 	// parentDir := os.Getenv("BUILDER_PARENT_DIR")
 	artifactDir := os.Getenv("BUILDER_ARTIFACT_DIR")
 
-	artifactZip := artifactDir+".zip"
+	if runtime.GOOS == "windows" {
+		artifactZip := artifactDir + ".zip"
 
-	// CreateZip temp dir.
-	outFile, err := os.Create(artifactZip)
-	if err != nil {
-		 log.Fatal(err)
+		// CreateZip temp dir.
+		outFile, err := os.Create(artifactZip)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		defer outFile.Close()
+
+		// Create a new zip archive.
+		w := zip.NewWriter(outFile)
+
+		// Add files from artifact dir to the artifact zip.
+		addFilesZip(w, artifactDir+"/", "")
+
+		err = w.Close()
+		if err != nil {
+			log.Fatal(err)
+		}
+	} else {
+
+		artifactTar := artifactDir + ".tar.gz"
+
+		outFile, err := os.Create(artifactTar)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		defer outFile.Close()
+
+		gw := gzip.NewWriter(outFile)
+		defer gw.Close()
+		tw := tar.NewWriter(gw)
+		defer tw.Close()
+
+		// Add files from artifact dir to the artifact tar.gz.
+		addFilesTar(tw, artifactDir+"/", "")
+
+		err = tw.Close()
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
-	
-	defer outFile.Close()
 
-	// Create a new zip archive.
-	w := zip.NewWriter(outFile)
-
-	// Add files from artifact dir to the artifact zip.
-	addFiles(w, artifactDir+"/", "")
-
-	err = w.Close()
-	if err != nil {
-		 log.Fatal(err)
-	}
 }
 
-//recursively add files
-func addFiles(w *zip.Writer, basePath, baseInZip string) {
+// recursively add files
+func addFilesZip(w *zip.Writer, basePath, baseInZip string) {
 	// Open the Directory
 	files, err := ioutil.ReadDir(basePath)
 	if err != nil {
-			fmt.Println(err)
+		fmt.Println(err)
 	}
 
 	for _, file := range files {
-			if !file.IsDir() {
-					dat, err := ioutil.ReadFile(basePath + file.Name())
-					if err != nil {
-							fmt.Println(err)
-					}
-
-					// Add some files to the archive.
-					f, err := w.Create(baseInZip + file.Name())
-					if err != nil {
-							fmt.Println(err)
-					}
-					_, err = f.Write(dat)
-					if err != nil {
-							fmt.Println(err)
-					}
-			} else if file.IsDir() {
-					// Recurse
-					newBase := basePath + file.Name() + "/"
-					addFiles(w, newBase, baseInZip  + file.Name() + "/")
+		if !file.IsDir() {
+			dat, err := ioutil.ReadFile(basePath + file.Name())
+			if err != nil {
+				fmt.Println(err)
 			}
+
+			// Add some files to the archive.
+			f, err := w.Create(baseInZip + file.Name())
+			if err != nil {
+				fmt.Println(err)
+			}
+			_, err = f.Write(dat)
+			if err != nil {
+				fmt.Println(err)
+			}
+		} else if file.IsDir() {
+			// Recurse
+			newBase := basePath + file.Name() + "/"
+			addFilesZip(w, newBase, baseInZip+file.Name()+"/")
+		}
+	}
+}
+
+func addFilesTar(w *tar.Writer, basePath, baseInZip string) {
+	// Open the Directory
+	files, err := ioutil.ReadDir(basePath)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	for _, file := range files {
+		if !file.IsDir() {
+			dat, err := ioutil.ReadFile(basePath + file.Name())
+			if err != nil {
+				fmt.Println(err)
+			}
+
+			header, err := tar.FileInfoHeader(file, file.Name())
+			if err != nil {
+				fmt.Println(err)
+			}
+
+			header.Name = baseInZip + file.Name()
+
+			// Add some files to the archive.
+			err = w.WriteHeader(header)
+			if err != nil {
+				fmt.Println(err)
+			}
+			_, err = w.Write(dat)
+			if err != nil {
+				fmt.Println(err)
+			}
+		} else if file.IsDir() {
+			// Recurse
+			newBase := basePath + file.Name() + "/"
+			addFilesTar(w, newBase, baseInZip+file.Name()+"/")
+		}
 	}
 }

--- a/compile/c#.go
+++ b/compile/c#.go
@@ -103,19 +103,27 @@ func packageCSharpArtifact(fullPath string) {
 
 	//create metadata, then copy contents to zip dir
 	utils.Metadata(artifactDir)
-	artifact.ZipArtifactDir()
 
-	//copy zip into open artifactDir, delete zip in workspace (keeps entire artifact contained)
-	exec.Command("cp", "-a", artifactDir+archiveExt, artifactDir).Run()
-	exec.Command("rm", artifactDir+archiveExt).Run()
+	if os.Getenv("ARTIFACT_ZIP_ENABLED") == "true" {
+		artifact.ZipArtifactDir()
 
-	// artifactName := artifact.NameArtifact(fullPath, extName)
+		//copy zip into open artifactDir, delete zip in workspace (keeps entire artifact contained)
+		exec.Command("cp", "-a", artifactDir+archiveExt, artifactDir).Run()
+		exec.Command("rm", artifactDir+archiveExt).Run()
 
-	// send artifact to user specified path
-	artifactStamp := os.Getenv("BUILDER_ARTIFACT_STAMP")
-	outputPath := os.Getenv("BUILDER_OUTPUT_PATH")
-	if outputPath != "" {
-		exec.Command("cp", "-a", artifactDir+"/"+artifactStamp+archiveExt, outputPath).Run()
+		// artifactName := artifact.NameArtifact(fullPath, extName)
+
+		// send artifact to user specified path or send to parent directory
+		artifactStamp := os.Getenv("BUILDER_ARTIFACT_STAMP")
+		outputPath := os.Getenv("BUILDER_OUTPUT_PATH")
+		if outputPath != "" {
+			exec.Command("cp", "-a", artifactDir+"/"+artifactStamp+archiveExt, outputPath).Run()
+		} else {
+			exec.Command("cp", "-a", artifactDir+"/"+artifactStamp+archiveExt, os.Getenv("BUILDER_PARENT_DIR")).Run()
+		}
+
+		//remove artifact directory
+		exec.Command("rm", "-r", artifactDir).Run()
 	}
 }
 

--- a/compile/c#.go
+++ b/compile/c#.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -83,6 +84,14 @@ func CSharp(filePath string) {
 }
 
 func packageCSharpArtifact(fullPath string) {
+	archiveExt := ""
+
+	if runtime.GOOS == "windows" {
+		archiveExt = ".zip"
+	} else {
+		archiveExt = ".tar.gz"
+	}
+
 	artifact.ArtifactDir()
 	artifactDir := os.Getenv("BUILDER_ARTIFACT_DIR")
 	//find artifact by extension
@@ -97,8 +106,8 @@ func packageCSharpArtifact(fullPath string) {
 	artifact.ZipArtifactDir()
 
 	//copy zip into open artifactDir, delete zip in workspace (keeps entire artifact contained)
-	exec.Command("cp", "-a", artifactDir+".zip", artifactDir).Run()
-	exec.Command("rm", artifactDir+".zip").Run()
+	exec.Command("cp", "-a", artifactDir+archiveExt, artifactDir).Run()
+	exec.Command("rm", artifactDir+archiveExt).Run()
 
 	// artifactName := artifact.NameArtifact(fullPath, extName)
 
@@ -106,7 +115,7 @@ func packageCSharpArtifact(fullPath string) {
 	artifactStamp := os.Getenv("BUILDER_ARTIFACT_STAMP")
 	outputPath := os.Getenv("BUILDER_OUTPUT_PATH")
 	if outputPath != "" {
-		exec.Command("cp", "-a", artifactDir+"/"+artifactStamp+".zip", outputPath).Run()
+		exec.Command("cp", "-a", artifactDir+"/"+artifactStamp+archiveExt, outputPath).Run()
 	}
 }
 

--- a/compile/go.go
+++ b/compile/go.go
@@ -13,10 +13,11 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 )
 
-//Go creates exe from file passed in as arg
+// Go creates exe from file passed in as arg
 func Go(filePath string) {
 
 	//Set default project type env for builder.yaml creation
@@ -64,9 +65,9 @@ func Go(filePath string) {
 		cmd.Dir = fullPath // or whatever directory it's in
 	} else {
 		//default
-		cmd = exec.Command("go", "build", buildFile)
+		cmd = exec.Command("go", "build", "-o", strings.TrimSuffix(utils.GetName(), ".git"))
 		cmd.Dir = fullPath // or whatever directory it's in
-		os.Setenv("BUILDER_BUILD_COMMAND", "go build "+buildFile)
+		os.Setenv("BUILDER_BUILD_COMMAND", "go build -o "+strings.TrimSuffix(utils.GetName(), ".git"))
 	}
 
 	//run cmd, check for err, log cmd
@@ -88,10 +89,21 @@ func Go(filePath string) {
 }
 
 func packageGoArtifact(fullPath string) {
+	archiveExt := ""
+	artifactExt := ""
+
+	if runtime.GOOS == "windows" {
+		archiveExt = ".zip"
+		artifactExt = ".exe"
+	} else {
+		archiveExt = ".tar.gz"
+		artifactExt = "executable"
+	}
+
 	artifact.ArtifactDir()
 	artifactDir := os.Getenv("BUILDER_ARTIFACT_DIR")
 	//find artifact by extension
-	_, extName := artifact.ExtExistsFunction(fullPath, ".exe")
+	_, extName := artifact.ExtExistsFunction(fullPath, artifactExt)
 	//copy artifact, then remove artifact in workspace
 	exec.Command("cp", "-a", fullPath+"/"+extName, artifactDir).Run()
 	exec.Command("rm", fullPath+"/"+extName).Run()
@@ -101,8 +113,8 @@ func packageGoArtifact(fullPath string) {
 	artifact.ZipArtifactDir()
 
 	//copy zip into open artifactDir, delete zip in workspace (keeps entire artifact contained)
-	exec.Command("cp", "-a", artifactDir+".zip", artifactDir).Run()
-	exec.Command("rm", artifactDir+".zip").Run()
+	exec.Command("cp", "-a", artifactDir+archiveExt, artifactDir).Run()
+	exec.Command("rm", artifactDir+archiveExt).Run()
 
 	// artifactName := artifact.NameArtifact(fullPath, extName)
 
@@ -110,6 +122,6 @@ func packageGoArtifact(fullPath string) {
 	artifactStamp := os.Getenv("BUILDER_ARTIFACT_STAMP")
 	outputPath := os.Getenv("BUILDER_OUTPUT_PATH")
 	if outputPath != "" {
-		exec.Command("cp", "-a", artifactDir+"/"+artifactStamp+".zip", outputPath).Run()
+		exec.Command("cp", "-a", artifactDir+"/"+artifactStamp+archiveExt, outputPath).Run()
 	}
 }

--- a/compile/go.go
+++ b/compile/go.go
@@ -108,20 +108,29 @@ func packageGoArtifact(fullPath string) {
 	exec.Command("cp", "-a", fullPath+"/"+extName, artifactDir).Run()
 	exec.Command("rm", fullPath+"/"+extName).Run()
 
-	//create metadata, then copy contents to zip dir
+	//create metadata
 	utils.Metadata(artifactDir)
-	artifact.ZipArtifactDir()
 
-	//copy zip into open artifactDir, delete zip in workspace (keeps entire artifact contained)
-	exec.Command("cp", "-a", artifactDir+archiveExt, artifactDir).Run()
-	exec.Command("rm", artifactDir+archiveExt).Run()
+	if os.Getenv("ARTIFACT_ZIP_ENABLED") == "true" {
+		//zip artifact
+		artifact.ZipArtifactDir()
 
-	// artifactName := artifact.NameArtifact(fullPath, extName)
+		//copy zip into open artifactDir, delete zip in workspace (keeps entire artifact contained)
+		exec.Command("cp", "-a", artifactDir+archiveExt, artifactDir).Run()
+		exec.Command("rm", artifactDir+archiveExt).Run()
 
-	// send artifact to user specified path
-	artifactStamp := os.Getenv("BUILDER_ARTIFACT_STAMP")
-	outputPath := os.Getenv("BUILDER_OUTPUT_PATH")
-	if outputPath != "" {
-		exec.Command("cp", "-a", artifactDir+"/"+artifactStamp+archiveExt, outputPath).Run()
+		// artifactName := artifact.NameArtifact(fullPath, extName)
+
+		// send artifact to user specified path or send to parent directory
+		artifactStamp := os.Getenv("BUILDER_ARTIFACT_STAMP")
+		outputPath := os.Getenv("BUILDER_OUTPUT_PATH")
+		if outputPath != "" {
+			exec.Command("cp", "-a", artifactDir+"/"+artifactStamp+archiveExt, outputPath).Run()
+		} else {
+			exec.Command("cp", "-a", artifactDir+"/"+artifactStamp+archiveExt, os.Getenv("BUILDER_PARENT_DIR")).Run()
+		}
+
+		//remove artifact directory
+		exec.Command("rm", "-r", artifactDir).Run()
 	}
 }

--- a/compile/java.go
+++ b/compile/java.go
@@ -101,18 +101,27 @@ func packageJavaArtifact(fullPath string) {
 
 	//create metadata, then copy contents to zip dir
 	utils.Metadata(artifactDir)
-	artifact.ZipArtifactDir()
 
-	//copy zip into open artifactDir, delete zip in workspace (keeps entire artifact contained)
-	exec.Command("cp", "-a", artifactDir+archiveExt, artifactDir).Run()
-	exec.Command("rm", artifactDir+archiveExt).Run()
+	if os.Getenv("ARTIFACT_ZIP_ENABLED") == "true" {
+		//zip artifact
+		artifact.ZipArtifactDir()
 
-	// artifactName := artifact.NameArtifact(fullPath, extName)
+		//copy zip into open artifactDir, delete zip in workspace (keeps entire artifact contained)
+		exec.Command("cp", "-a", artifactDir+archiveExt, artifactDir).Run()
+		exec.Command("rm", artifactDir+archiveExt).Run()
 
-	// send artifact to user specified path
-	artifactStamp := os.Getenv("BUILDER_ARTIFACT_STAMP")
-	outputPath := os.Getenv("BUILDER_OUTPUT_PATH")
-	if outputPath != "" {
-		exec.Command("cp", "-a", artifactDir+"/"+artifactStamp+archiveExt, outputPath).Run()
+		// artifactName := artifact.NameArtifact(fullPath, extName)
+
+		// send artifact to user specified path or send to parent directory
+		artifactStamp := os.Getenv("BUILDER_ARTIFACT_STAMP")
+		outputPath := os.Getenv("BUILDER_OUTPUT_PATH")
+		if outputPath != "" {
+			exec.Command("cp", "-a", artifactDir+"/"+artifactStamp+archiveExt, outputPath).Run()
+		} else {
+			exec.Command("cp", "-a", artifactDir+"/"+artifactStamp+archiveExt, os.Getenv("BUILDER_PARENT_DIR")).Run()
+		}
+
+		//remove artifact directory
+		exec.Command("rm", "-r", artifactDir).Run()
 	}
 }

--- a/compile/java.go
+++ b/compile/java.go
@@ -10,10 +10,11 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 )
 
-//Java does ...
+// Java does ...
 func Java(filePath string) {
 	//Set default project type env for builder.yaml creation
 	projectType := os.Getenv("BUILDER_PROJECT_TYPE")
@@ -82,6 +83,14 @@ func Java(filePath string) {
 	logger.InfoLogger.Println("Java project compiled successfully.")
 }
 func packageJavaArtifact(fullPath string) {
+	archiveExt := ""
+
+	if runtime.GOOS == "windows" {
+		archiveExt = ".zip"
+	} else {
+		archiveExt = ".tar.gz"
+	}
+
 	artifact.ArtifactDir()
 	artifactDir := os.Getenv("BUILDER_ARTIFACT_DIR")
 	//find artifact by extension
@@ -95,8 +104,8 @@ func packageJavaArtifact(fullPath string) {
 	artifact.ZipArtifactDir()
 
 	//copy zip into open artifactDir, delete zip in workspace (keeps entire artifact contained)
-	exec.Command("cp", "-a", artifactDir+".zip", artifactDir).Run()
-	exec.Command("rm", artifactDir+".zip").Run()
+	exec.Command("cp", "-a", artifactDir+archiveExt, artifactDir).Run()
+	exec.Command("rm", artifactDir+archiveExt).Run()
 
 	// artifactName := artifact.NameArtifact(fullPath, extName)
 
@@ -104,6 +113,6 @@ func packageJavaArtifact(fullPath string) {
 	artifactStamp := os.Getenv("BUILDER_ARTIFACT_STAMP")
 	outputPath := os.Getenv("BUILDER_OUTPUT_PATH")
 	if outputPath != "" {
-		exec.Command("cp", "-a", artifactDir+"/"+artifactStamp+".zip", outputPath).Run()
+		exec.Command("cp", "-a", artifactDir+"/"+artifactStamp+archiveExt, outputPath).Run()
 	}
 }

--- a/compile/npm.go
+++ b/compile/npm.go
@@ -155,19 +155,28 @@ func packageNpmArtifact(fullPath string) {
 
 	//create metadata, then copy contents to zip dir
 	utils.Metadata(artifactDir)
-	artifact.ZipArtifactDir()
 
-	//copy zip into open artifactDir, delete zip in workspace (keeps entire artifact contained)
-	exec.Command("cp", "-a", artifactDir+archiveExt, artifactDir).Run()
-	exec.Command("rm", artifactDir+archiveExt).Run()
+	if os.Getenv("ARTIFACT_ZIP_ENABLED") == "true" {
+		//zip artifact
+		artifact.ZipArtifactDir()
 
-	// artifactName := artifact.NameArtifact(fullPath, extName)
+		//copy zip into open artifactDir, delete zip in workspace (keeps entire artifact contained)
+		exec.Command("cp", "-a", artifactDir+archiveExt, artifactDir).Run()
+		exec.Command("rm", artifactDir+archiveExt).Run()
 
-	// send artifact to user specified path
-	artifactStamp := os.Getenv("BUILDER_ARTIFACT_STAMP")
-	outputPath := os.Getenv("BUILDER_OUTPUT_PATH")
-	if outputPath != "" {
-		exec.Command("cp", "-a", artifactDir+"/"+artifactStamp+archiveExt, outputPath).Run()
+		// artifactName := artifact.NameArtifact(fullPath, extName)
+
+		// send artifact to user specified path or send to parent directory
+		artifactStamp := os.Getenv("BUILDER_ARTIFACT_STAMP")
+		outputPath := os.Getenv("BUILDER_OUTPUT_PATH")
+		if outputPath != "" {
+			exec.Command("cp", "-a", artifactDir+"/"+artifactStamp+archiveExt, outputPath).Run()
+		} else {
+			exec.Command("cp", "-a", artifactDir+"/"+artifactStamp+archiveExt, os.Getenv("BUILDER_PARENT_DIR")).Run()
+		}
+
+		//remove artifact directory
+		exec.Command("rm", "-r", artifactDir).Run()
 	}
 }
 

--- a/compile/npm.go
+++ b/compile/npm.go
@@ -12,12 +12,13 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
 )
 
-//Npm creates zip from files passed in as arg
+// Npm creates zip from files passed in as arg
 func Npm() {
 	//Set default project type env for builder.yaml creation
 	projectType := os.Getenv("BUILDER_PROJECT_TYPE")
@@ -136,6 +137,14 @@ func Npm() {
 }
 
 func packageNpmArtifact(fullPath string) {
+	archiveExt := ""
+
+	if runtime.GOOS == "windows" {
+		archiveExt = ".zip"
+	} else {
+		archiveExt = ".tar.gz"
+	}
+
 	artifact.ArtifactDir()
 	artifactDir := os.Getenv("BUILDER_ARTIFACT_DIR")
 	//find artifact by extension
@@ -149,8 +158,8 @@ func packageNpmArtifact(fullPath string) {
 	artifact.ZipArtifactDir()
 
 	//copy zip into open artifactDir, delete zip in workspace (keeps entire artifact contained)
-	exec.Command("cp", "-a", artifactDir+".zip", artifactDir).Run()
-	exec.Command("rm", artifactDir+".zip").Run()
+	exec.Command("cp", "-a", artifactDir+archiveExt, artifactDir).Run()
+	exec.Command("rm", artifactDir+archiveExt).Run()
 
 	// artifactName := artifact.NameArtifact(fullPath, extName)
 
@@ -158,11 +167,11 @@ func packageNpmArtifact(fullPath string) {
 	artifactStamp := os.Getenv("BUILDER_ARTIFACT_STAMP")
 	outputPath := os.Getenv("BUILDER_OUTPUT_PATH")
 	if outputPath != "" {
-		exec.Command("cp", "-a", artifactDir+"/"+artifactStamp+".zip", outputPath).Run()
+		exec.Command("cp", "-a", artifactDir+"/"+artifactStamp+archiveExt, outputPath).Run()
 	}
 }
 
-//recursively add files
+// recursively add files
 func addNpmFiles(w *zip.Writer, basePath, baseInZip string) {
 	// Open the Directory
 	files, err := ioutil.ReadDir(basePath)

--- a/compile/python.go
+++ b/compile/python.go
@@ -12,12 +12,13 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
 )
 
-//Python creates zip from files passed in as arg
+// Python creates zip from files passed in as arg
 func Python() {
 	//Set default project type env for builder.yaml creation
 	projectType := os.Getenv("BUILDER_PROJECT_TYPE")
@@ -134,6 +135,14 @@ func Python() {
 }
 
 func packagePythonArtifact(fullPath string) {
+	archiveExt := ""
+
+	if runtime.GOOS == "windows" {
+		archiveExt = ".zip"
+	} else {
+		archiveExt = ".tar.gz"
+	}
+
 	artifact.ArtifactDir()
 	artifactDir := os.Getenv("BUILDER_ARTIFACT_DIR")
 	//find artifact by extension
@@ -147,8 +156,8 @@ func packagePythonArtifact(fullPath string) {
 	artifact.ZipArtifactDir()
 
 	//copy zip into open artifactDir, delete zip in workspace (keeps entire artifact contained)
-	exec.Command("cp", "-a", artifactDir+".zip", artifactDir).Run()
-	exec.Command("rm", artifactDir+".zip").Run()
+	exec.Command("cp", "-a", artifactDir+archiveExt, artifactDir).Run()
+	exec.Command("rm", artifactDir+archiveExt).Run()
 
 	// artifactName := artifact.NameArtifact(fullPath, extName)
 
@@ -156,11 +165,11 @@ func packagePythonArtifact(fullPath string) {
 	artifactStamp := os.Getenv("BUILDER_ARTIFACT_STAMP")
 	outputPath := os.Getenv("BUILDER_OUTPUT_PATH")
 	if outputPath != "" {
-		exec.Command("cp", "-a", artifactDir+"/"+artifactStamp+".zip", outputPath).Run()
+		exec.Command("cp", "-a", artifactDir+"/"+artifactStamp+archiveExt, outputPath).Run()
 	}
 }
 
-//recursively add files
+// recursively add files
 func addPythonFiles(w *zip.Writer, basePath, baseInZip string) {
 	// Open the Directory
 	files, err := ioutil.ReadDir(basePath)

--- a/compile/python.go
+++ b/compile/python.go
@@ -153,19 +153,28 @@ func packagePythonArtifact(fullPath string) {
 
 	//create metadata, then copy contents to zip dir
 	utils.Metadata(artifactDir)
-	artifact.ZipArtifactDir()
 
-	//copy zip into open artifactDir, delete zip in workspace (keeps entire artifact contained)
-	exec.Command("cp", "-a", artifactDir+archiveExt, artifactDir).Run()
-	exec.Command("rm", artifactDir+archiveExt).Run()
+	if os.Getenv("ARTIFACT_ZIP_ENABLED") == "true" {
+		//zip artifact
+		artifact.ZipArtifactDir()
 
-	// artifactName := artifact.NameArtifact(fullPath, extName)
+		//copy zip into open artifactDir, delete zip in workspace (keeps entire artifact contained)
+		exec.Command("cp", "-a", artifactDir+archiveExt, artifactDir).Run()
+		exec.Command("rm", artifactDir+archiveExt).Run()
 
-	// send artifact to user specified path
-	artifactStamp := os.Getenv("BUILDER_ARTIFACT_STAMP")
-	outputPath := os.Getenv("BUILDER_OUTPUT_PATH")
-	if outputPath != "" {
-		exec.Command("cp", "-a", artifactDir+"/"+artifactStamp+archiveExt, outputPath).Run()
+		// artifactName := artifact.NameArtifact(fullPath, extName)
+
+		// send artifact to user specified path or send to parent directory
+		artifactStamp := os.Getenv("BUILDER_ARTIFACT_STAMP")
+		outputPath := os.Getenv("BUILDER_OUTPUT_PATH")
+		if outputPath != "" {
+			exec.Command("cp", "-a", artifactDir+"/"+artifactStamp+archiveExt, outputPath).Run()
+		} else {
+			exec.Command("cp", "-a", artifactDir+"/"+artifactStamp+archiveExt, os.Getenv("BUILDER_PARENT_DIR")).Run()
+		}
+
+		//remove artifact directory
+		exec.Command("rm", "-r", artifactDir).Run()
 	}
 }
 

--- a/compile/ruby.go
+++ b/compile/ruby.go
@@ -12,12 +12,13 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
 )
 
-//Ruby creates zip from files passed in as arg
+// Ruby creates zip from files passed in as arg
 func Ruby() {
 	//Set default project type env for builder.yaml creation
 	projectType := os.Getenv("BUILDER_PROJECT_TYPE")
@@ -133,6 +134,14 @@ func Ruby() {
 }
 
 func packageRubyArtifact(fullPath string) {
+	archiveExt := ""
+
+	if runtime.GOOS == "windows" {
+		archiveExt = ".zip"
+	} else {
+		archiveExt = ".tar.gz"
+	}
+
 	artifact.ArtifactDir()
 	artifactDir := os.Getenv("BUILDER_ARTIFACT_DIR")
 	//find artifact by extension
@@ -146,8 +155,8 @@ func packageRubyArtifact(fullPath string) {
 	artifact.ZipArtifactDir()
 
 	//copy zip into open artifactDir, delete zip in workspace (keeps entire artifact contained)
-	exec.Command("cp", "-a", artifactDir+".zip", artifactDir).Run()
-	exec.Command("rm", artifactDir+".zip").Run()
+	exec.Command("cp", "-a", artifactDir+archiveExt, artifactDir).Run()
+	exec.Command("rm", artifactDir+archiveExt).Run()
 
 	// artifactName := artifact.NameArtifact(fullPath, extName)
 
@@ -155,11 +164,11 @@ func packageRubyArtifact(fullPath string) {
 	artifactStamp := os.Getenv("BUILDER_ARTIFACT_STAMP")
 	outputPath := os.Getenv("BUILDER_OUTPUT_PATH")
 	if outputPath != "" {
-		exec.Command("cp", "-a", artifactDir+"/"+artifactStamp+".zip", outputPath).Run()
+		exec.Command("cp", "-a", artifactDir+"/"+artifactStamp+archiveExt, outputPath).Run()
 	}
 }
 
-//recursively add files
+// recursively add files
 func addRubyFiles(w *zip.Writer, basePath, baseInZip string) {
 	// Open the Directory
 	files, err := ioutil.ReadDir(basePath)

--- a/compile/ruby.go
+++ b/compile/ruby.go
@@ -152,19 +152,28 @@ func packageRubyArtifact(fullPath string) {
 
 	//create metadata, then copy contents to zip dir
 	utils.Metadata(artifactDir)
-	artifact.ZipArtifactDir()
 
-	//copy zip into open artifactDir, delete zip in workspace (keeps entire artifact contained)
-	exec.Command("cp", "-a", artifactDir+archiveExt, artifactDir).Run()
-	exec.Command("rm", artifactDir+archiveExt).Run()
+	if os.Getenv("ARTIFACT_ZIP_ENABLED") == "true" {
+		//zip artifact
+		artifact.ZipArtifactDir()
 
-	// artifactName := artifact.NameArtifact(fullPath, extName)
+		//copy zip into open artifactDir, delete zip in workspace (keeps entire artifact contained)
+		exec.Command("cp", "-a", artifactDir+archiveExt, artifactDir).Run()
+		exec.Command("rm", artifactDir+archiveExt).Run()
 
-	// send artifact to user specified path
-	artifactStamp := os.Getenv("BUILDER_ARTIFACT_STAMP")
-	outputPath := os.Getenv("BUILDER_OUTPUT_PATH")
-	if outputPath != "" {
-		exec.Command("cp", "-a", artifactDir+"/"+artifactStamp+archiveExt, outputPath).Run()
+		// artifactName := artifact.NameArtifact(fullPath, extName)
+
+		// send artifact to user specified path or send to parent directory
+		artifactStamp := os.Getenv("BUILDER_ARTIFACT_STAMP")
+		outputPath := os.Getenv("BUILDER_OUTPUT_PATH")
+		if outputPath != "" {
+			exec.Command("cp", "-a", artifactDir+"/"+artifactStamp+archiveExt, outputPath).Run()
+		} else {
+			exec.Command("cp", "-a", artifactDir+"/"+artifactStamp+archiveExt, os.Getenv("BUILDER_PARENT_DIR")).Run()
+		}
+
+		//remove artifact directory
+		exec.Command("rm", "-r", artifactDir).Run()
 	}
 }
 

--- a/utils/checkArgs.go
+++ b/utils/checkArgs.go
@@ -7,7 +7,7 @@ import (
 	"os/exec"
 )
 
-//CheckArgs is...
+// CheckArgs is...
 func CheckArgs() {
 	//Repo
 	repo := GetRepoURL()
@@ -42,6 +42,9 @@ func CheckArgs() {
 					fmt.Println("Output Path already present")
 				}
 			}
+		}
+		if v == "--zip" || v == "-z" {
+			os.Setenv("ARTIFACT_ZIP_ENABLED", "true")
 		}
 	}
 }


### PR DESCRIPTION
- Artifacts are no longer zipped by default. The user must pass --zip or -z as a command line argument for the artifact to be zipped.
- Archived artifacts are now zipped based on OS. Windows artifacts will be .zip archives and Mac and Linux will be .tar.gz archives.
- Golang projects now correctly add the artifact to the artifact folder or archive. Previously only .exe files were searched for and added.
