### PR TITLE
Fixed merge overwrite in zipDir.go

### DIFF
--- a/artifact/zipDir.go
+++ b/artifact/zipDir.go
@@ -22,7 +22,7 @@ func ZipArtifactDir() {
 		// CreateZip temp dir.
 		outFile, err := os.Create(artifactZip)
 		if err != nil {
-      log.Fatal("failed to create artifact directory", err)
+			log.Fatal("failed to create artifact directory", err)
 		}
 
 		defer outFile.Close()
@@ -34,8 +34,8 @@ func ZipArtifactDir() {
 		addFilesZip(w, artifactDir+"/", "")
 
 		err = w.Close()
-		if err != nil {			
-      log.Fatal("failed to create artifact directory", err)
+		if err != nil {
+			log.Fatal("failed to create artifact directory", err)
 		}
 	} else {
 
@@ -43,7 +43,7 @@ func ZipArtifactDir() {
 
 		outFile, err := os.Create(artifactTar)
 		if err != nil {
-       log.Fatal("failed to create artifact directory", err)
+			log.Fatal("failed to create artifact directory", err)
 		}
 
 		defer outFile.Close()
@@ -58,16 +58,18 @@ func ZipArtifactDir() {
 
 		err = tw.Close()
 		if err != nil {
-       log.Fatal("failed to create artifact", err)
+			log.Fatal("failed to create artifact", err)
 		}
 	}
 
 }
 
-
 // recursively add files
-func addFiles(w *zip.Writer, basePath, baseInZip string) {
-		fmt.Println(err)
+func addFilesZip(w *zip.Writer, basePath, baseInZip string) {
+	// Open the Directory
+	files, err := ioutil.ReadDir(basePath)
+	if err != nil {
+		log.Error("failed to read zip directory", err)
 	}
 
 	for _, file := range files {
@@ -79,12 +81,12 @@ func addFiles(w *zip.Writer, basePath, baseInZip string) {
 
 			// Add some files to the archive.
 			f, err := w.Create(baseInZip + file.Name())
-			if err != nil {	
-        log.Error("failed to create zip", err)
+			if err != nil {
+				log.Error("failed to create zip", err)
 			}
 			_, err = f.Write(dat)
 			if err != nil {
-        log.Error("failed to add files to zip", err)
+				log.Error("failed to add files to zip", err)
 			}
 		} else if file.IsDir() {
 			// Recurse


### PR DESCRIPTION
The latest merge overwrote part of the addFilesZip method in zipDir.go. These changes add back the missing code.