### PR TITLE
fixed clone and compiler copy for windows

### DIFF
--- a/compile/java.go
+++ b/compile/java.go
@@ -11,9 +11,12 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
+
+	cp "github.com/otiai10/copy"
 )
 
 // Java does ...
@@ -149,8 +152,12 @@ func packageJavaArtifact(fullPath string) {
 	//find artifact by extension
 	_, extName := artifact.ExtExistsFunction(fullPath, ".jar")
 	os.Setenv("BUILDER_ARTIFACT_NAMES", extName)
+
 	//copy artifact, then remove artifact in workspace
-	exec.Command("cp", "-a", fullPath+"/"+extName, artifactDir).Run()
+	err := cp.Copy(fullPath+"/"+extName, artifactDir+"/"+extName)
+	if err != nil {
+		spinner.LogMessage(err.Error(), "warn")
+	}
 
 	// If outputpath provided also cp artifacts to that location
 	if outputPath != "" {
@@ -161,12 +168,18 @@ func packageJavaArtifact(fullPath string) {
 			}
 		}
 
-		exec.Command("cp", "-a", fullPath+"/"+extName, outputPath).Run()
+		err := cp.Copy(fullPath+"/"+extName, outputPath+"/"+extName)
+		if err != nil {
+			spinner.LogMessage(err.Error(), "warn")
+		}
 
 		spinner.LogMessage("Artifact(s) copied to output path provided", "info")
 	}
 
-	exec.Command("rm", fullPath+"/"+extName).Run()
+	errRemove := os.Remove(fullPath + "/" + extName)
+	if errRemove != nil {
+		spinner.LogMessage(errRemove.Error(), "warn")
+	}
 
 	//create metadata, then copy contents to zip dir
 	utils.Metadata(artifactDir)
@@ -175,22 +188,29 @@ func packageJavaArtifact(fullPath string) {
 		//zip artifact
 		artifact.ZipArtifactDir()
 
-		//copy zip into open artifactDir, delete zip in workspace (keeps entire artifact contained)
-		exec.Command("cp", "-a", artifactDir+archiveExt, artifactDir).Run()
-		exec.Command("rm", artifactDir+archiveExt).Run()
-
-		// artifactName := artifact.NameArtifact(fullPath, extName)
-
-		// send artifact to user specified path or send to parent directory
-		artifactStamp := os.Getenv("BUILDER_ARTIFACT_STAMP")
-		outputPath := os.Getenv("BUILDER_OUTPUT_PATH")
-		if outputPath != "" {
-			exec.Command("cp", "-a", artifactDir+"/"+artifactStamp+archiveExt, outputPath).Run()
-		} else {
-			exec.Command("cp", "-a", artifactDir+"/"+artifactStamp+archiveExt, os.Getenv("BUILDER_PARENT_DIR")).Run()
+		//remove uncompressed artifact
+		err := os.Remove(artifactDir + "/" + extName)
+		if err != nil {
+			spinner.LogMessage(err.Error(), "warn")
 		}
 
-		//remove artifact directory
-		exec.Command("rm", "-r", artifactDir).Run()
+		// send artifact to user specified path or send to artifact directory
+		outputPath := os.Getenv("BUILDER_OUTPUT_PATH")
+		if outputPath != "" {
+			err := cp.Copy(artifactDir+archiveExt, outputPath+"/"+filepath.Base(artifactDir)+archiveExt)
+			if err != nil {
+				spinner.LogMessage(err.Error(), "warn")
+			}
+		} else {
+			err := cp.Copy(artifactDir+archiveExt, artifactDir+"/"+filepath.Base(artifactDir)+archiveExt)
+			if err != nil {
+				spinner.LogMessage(err.Error(), "warn")
+			}
+		}
+
+		errRemove := os.Remove(artifactDir + archiveExt)
+		if errRemove != nil {
+			spinner.LogMessage(errRemove.Error(), "warn")
+		}
 	}
 }

--- a/compile/python.go
+++ b/compile/python.go
@@ -13,10 +13,13 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
 	"time"
+
+	cp "github.com/otiai10/copy"
 )
 
 // Python creates zip from files passed in as arg
@@ -39,7 +42,10 @@ func Python() {
 	os.Mkdir(tempWorkspace, 0755)
 
 	//add hidden dir contents to temp dir, install dependencies
-	exec.Command("cp", "-a", hiddenDir+"/.", tempWorkspace).Run()
+	err := cp.Copy(hiddenDir+"/.", tempWorkspace)
+	if err != nil {
+		spinner.LogMessage(err.Error(), "warn")
+	}
 
 	//define dir path for command to run
 	var fullPath string
@@ -186,8 +192,12 @@ func packagePythonArtifact(fullPath string) {
 	//find artifact by extension
 	_, extName := artifact.ExtExistsFunction(workspaceDir, ".zip")
 	os.Setenv("BUILDER_ARTIFACT_NAMES", extName)
+
 	//copy artifact, then remove artifact in workspace
-	exec.Command("cp", "-a", workspaceDir+"/"+extName, artifactDir).Run()
+	err := cp.Copy(workspaceDir+"/"+extName, artifactDir+"/"+extName)
+	if err != nil {
+		spinner.LogMessage(err.Error(), "warn")
+	}
 
 	// If outputpath provided also cp artifacts to that location
 	if outputPath != "" {
@@ -198,12 +208,18 @@ func packagePythonArtifact(fullPath string) {
 			}
 		}
 
-		exec.Command("cp", "-a", workspaceDir+"/"+extName, outputPath).Run()
+		err := cp.Copy(workspaceDir+"/"+extName, outputPath+"/"+extName)
+		if err != nil {
+			spinner.LogMessage(err.Error(), "warn")
+		}
 
 		spinner.LogMessage("Artifact(s) copied to output path provided", "info")
 	}
 
-	exec.Command("rm", workspaceDir+"/"+extName).Run()
+	errRemove := os.Remove(workspaceDir + "/" + extName)
+	if errRemove != nil {
+		spinner.LogMessage(errRemove.Error(), "warn")
+	}
 
 	//create metadata, then copy contents to zip dir
 	utils.Metadata(artifactDir)
@@ -212,23 +228,30 @@ func packagePythonArtifact(fullPath string) {
 		//zip artifact
 		artifact.ZipArtifactDir()
 
-		//copy zip into open artifactDir, delete zip in workspace (keeps entire artifact contained)
-		exec.Command("cp", "-a", artifactDir+archiveExt, artifactDir).Run()
-		exec.Command("rm", artifactDir+archiveExt).Run()
-
-		// artifactName := artifact.NameArtifact(fullPath, extName)
-
-		// send artifact to user specified path or send to parent directory
-		artifactStamp := os.Getenv("BUILDER_ARTIFACT_STAMP")
-		outputPath := os.Getenv("BUILDER_OUTPUT_PATH")
-		if outputPath != "" {
-			exec.Command("cp", "-a", artifactDir+"/"+artifactStamp+archiveExt, outputPath).Run()
-		} else {
-			exec.Command("cp", "-a", artifactDir+"/"+artifactStamp+archiveExt, os.Getenv("BUILDER_PARENT_DIR")).Run()
+		//remove uncompressed artifact
+		err := os.Remove(artifactDir + "/" + extName)
+		if err != nil {
+			spinner.LogMessage(err.Error(), "warn")
 		}
 
-		//remove artifact directory
-		exec.Command("rm", "-r", artifactDir).Run()
+		// send artifact to user specified path or send to artifact directory
+		outputPath := os.Getenv("BUILDER_OUTPUT_PATH")
+		if outputPath != "" {
+			err := cp.Copy(artifactDir+archiveExt, outputPath+"/"+filepath.Base(artifactDir)+archiveExt)
+			if err != nil {
+				spinner.LogMessage(err.Error(), "warn")
+			}
+		} else {
+			err := cp.Copy(artifactDir+archiveExt, artifactDir+"/"+filepath.Base(artifactDir)+archiveExt)
+			if err != nil {
+				spinner.LogMessage(err.Error(), "warn")
+			}
+		}
+
+		errRemove := os.Remove(artifactDir + archiveExt)
+		if errRemove != nil {
+			spinner.LogMessage(errRemove.Error(), "warn")
+		}
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/manifoldco/promptui v0.8.0
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
+	github.com/otiai10/copy v1.12.0 // indirect
 	github.com/theckman/yacspin v0.13.12
 	github.com/zserge/lorca v0.1.10
 	go.uber.org/zap v1.24.0

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,9 @@ github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/otiai10/copy v1.12.0 h1:cLMgSQnXBs1eehF0Wy/FAGsgDTDmAqFR7rQylBb1nDY=
+github.com/otiai10/copy v1.12.0/go.mod h1:rSaLseMUsZFFbsFGc7wCJnnkTAvdc5L6VWxPE4308Ww=
+github.com/otiai10/mint v1.5.1/go.mod h1:MJm72SBthJjz8qhefc4z1PYEieWmy8Bku7CjcAqyUSM=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -98,6 +101,7 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/utils/cloneRepoFiles.go
+++ b/utils/cloneRepoFiles.go
@@ -3,8 +3,9 @@ package utils
 import (
 	"Builder/spinner"
 	"os"
-	"os/exec"
 	"path/filepath"
+
+	cp "github.com/otiai10/copy"
 )
 
 // CloneRepo grabs url and clones the repo/copies current dir
@@ -13,29 +14,27 @@ func CloneRepoFiles(from string, to string) {
 	fromPath, _ := filepath.Abs(from)
 	toPath, _ := filepath.Abs(to)
 
-	files, err := os.ReadDir(fromPath)
-	if err != nil {
-		spinner.LogMessage(err.Error(), "fatal")
-	}
-
 	// Copy all but Builder created dir
 	if os.Getenv("BUILDER_BUILDS_DIR") != "" { // A different folder to store builds is provided
-		for _, file := range files {
-			if file.Name() != os.Getenv("BUILDER_BUILDS_DIR") {
-				//copy files to given path
-				cmd := exec.Command("cp", "-r", file.Name(), toPath)
-				cmd.Dir = fromPath
-				cmd.Run()
-			}
+		opt := cp.Options{
+			Skip: func(info os.FileInfo, src, dest string) (bool, error) {
+				return info.Name() == os.Getenv("BUILDER_BUILDS_DIR"), nil
+			},
+		}
+		err := cp.Copy(fromPath, toPath, opt)
+		if err != nil {
+			spinner.LogMessage(err.Error(), "fatal")
 		}
 	} else { // Builds are stored in default named 'builder' folder
-		for _, file := range files {
-			if file.Name() != "builder" {
-				//copy files to given path
-				cmd := exec.Command("cp", "-r", file.Name(), toPath)
-				cmd.Dir = fromPath
-				cmd.Run()
-			}
+		// copy files to given path
+		opt := cp.Options{
+			Skip: func(info os.FileInfo, src, dest string) (bool, error) {
+				return info.Name() == "builder", nil
+			},
+		}
+		err := cp.Copy(fromPath, toPath, opt)
+		if err != nil {
+			spinner.LogMessage(err.Error(), "fatal")
 		}
 	}
 }


### PR DESCRIPTION
The function for copying cloned files into the builder folder was using cp to perform the copy, which would fail on Windows. This replaces that with a Go package that handles the copying using the built-in Go IO and OS packages, fixing the compatibility with Windows.